### PR TITLE
fix: 修复stringifyWithLoopProtection函数中replacer的调用逻辑

### DIFF
--- a/packages/basic/src/utils/create/utils.ts
+++ b/packages/basic/src/utils/create/utils.ts
@@ -32,7 +32,11 @@ export function stringifyWithLoopProtection(obj: any, replacer?: any, space?: an
         return undefined;
       }
 
-      return replacer(key, value);
+      if (typeof replacer === 'function') {
+        return replacer(key, value);
+      }
+
+      return value;
     },
     space,
   );


### PR DESCRIPTION
cherry-pick into release/v1.7.2