### PR TITLE
feat: 将后续的类型引用解析、泛型类型解析移植回旧版本以支持类型匹配

### DIFF
--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -360,7 +360,7 @@ function unorderedArrayEqual<T>(a: T[], b: T[]) {
 /**
  * 解析类型引用到实际的类型定义
  * @param typeAnnotation 需要解析的类型标注
- * @returns 如果解析成功则返回解析后的类型属性，解析失败返回null
+ * @returns 如果解析成功则返回解析后的类型属性，解析失败返回undefined
  */
 function resolveTypeReference(typeAnnotation: TypeAnnotation) {
   if (typeAnnotation.typeKind === "reference") {

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -356,6 +356,24 @@ function unorderedArrayEqual<T>(a: T[], b: T[]) {
   return xor(a, b).length === 0;
 }
 
+/**
+ * 解析类型引用到实际的类型定义
+ * @param typeAnnotation 需要解析的类型标注
+ * @returns 如果解析成功则返回解析后的类型属性，解析失败返回null
+ */
+function resolveTypeReference(typeAnnotation: TypeAnnotation) {
+  if (typeAnnotation.typeKind === "reference") {
+    const typeKey = genSortedTypeKey(typeAnnotation);
+    const candidateDef = typeDefinitionMap[typeKey];
+    // 如果仍然是type reference，那么视作失败
+    if (candidateDef?.concept === "TypeAnnotation" && candidateDef.typeKind === "reference") {
+      return undefined;
+    }
+    return candidateDef;
+  }
+  return undefined;
+}
+
 function exactMatchShapeAgainstDef(value, def: any): boolean {
   function isMatchForPrimitive(value, ty) {
     const valueTypeStr = Object.prototype.toString.call(value);
@@ -410,6 +428,11 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
       }
     }
     return false;
+  } else if (def.typeKind === "reference") {
+    const resolved = resolveTypeReference(def);
+    if (resolved) {
+      return exactMatchShapeAgainstDef(value, resolved);
+    }
   }
   return false;
 }

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -406,6 +406,25 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
     }
     return false;
   } else if (def.typeKind === "generic") {
+    if (def.typeName === "List" && def.typeNamespace === "nasl.collection") {
+      const targetTy: TypeAnnotation = def.typeArguments[0];
+      if (!targetTy || !Array.isArray(value)) {
+        return false;
+      }
+      return value.every((item) => exactMatchShapeAgainstDef(item, targetTy));
+    } else if (def.typeName === "Map" && def.typeNamespace === "nasl.collection") {
+      const keyTy = def.typeArguments[0];
+      const valueTy = def.typeArguments[1];
+      if (!keyTy || !valueTy || typeof value !== "object" || value === null || Array.isArray(value)) {
+        return false;
+      }
+      for (const [k, v] of Object.entries(value)) {
+        if (!exactMatchShapeAgainstDef(k, keyTy) || !exactMatchShapeAgainstDef(v, valueTy)) {
+          return false;
+        }
+      }
+      return true;
+    }
     return isInstanceOf(value, genSortedTypeKey(def));
   } else if (def.properties) {
     const properties = def.properties;

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -4,6 +4,7 @@ import moment from "moment";
 import { flatMap, xor } from "lodash";
 
 import { getAppTimezone, safeNewDate } from "../utils";
+import { type TypeAnnotation } from "./types";
 import Config from "../../config";
 
 function tryJSONParse(str) {

--- a/packages/basic/src/init/dataTypes/types.ts
+++ b/packages/basic/src/init/dataTypes/types.ts
@@ -1,0 +1,32 @@
+export type TypeAnnotation =
+  | {
+      typeKind: "primitive";
+      typeNamespace: string;
+      typeName: string;
+      concept: "TypeAnnotation";
+    }
+  | { typeKind: "reference"; typeName: string; typeNamespace: string; concept: "TypeAnnotation" }
+  | {
+      typeKind: "union";
+      typeArguments: TypeAnnotation[];
+      typeName: string;
+      typeNamespace: string;
+      concept: "TypeAnnotation";
+    }
+  | {
+      typeKind: "anonymousStructure";
+      properties: TypeAnnotation[];
+      typeName: undefined;
+      typeNamespace: undefined;
+      concept: "TypeAnnotation";
+    }
+  | {
+      typeKind: "generic";
+      typeArguments: TypeAnnotation[];
+      typeName: string;
+      typeNamespace: string;
+      concept: "TypeAnnotation";
+    };
+type DefaultValue = {
+  expression: { concept: "StringLiteral"; value: string | null | undefined } | {} | null;
+};


### PR DESCRIPTION
1. 支持解析引用类型。这样包含引用类型时，模式匹配工作正常。