### PR TITLE
fix(vue3): 更新依赖lock

### DIFF
--- a/packages/vue3/source/pc/pnpm-lock.yaml
+++ b/packages/vue3/source/pc/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@lcap/basic-template':
-        specifier: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/basic-template%402.0.1/zip.tgz
-        version: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/basic-template%402.0.1/zip.tgz
+        specifier: ./lcap_modules/@lcap/basic-template@2.0.1/zip.tgz
+        version: file:lcap_modules/@lcap/basic-template@2.0.1/zip.tgz
       '@lcap/element-plus':
-        specifier: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/element-plus%401.0.0/zip.tgz
-        version: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/element-plus%401.0.0/zip.tgz(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))
+        specifier: ./lcap_modules/@lcap/element-plus@1.0.0/zip.tgz
+        version: file:lcap_modules/@lcap/element-plus@1.0.0/zip.tgz(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
@@ -236,12 +236,12 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@lcap/basic-template@http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/basic-template%402.0.1/zip.tgz':
-    resolution: {tarball: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/basic-template%402.0.1/zip.tgz}
+  '@lcap/basic-template@file:lcap_modules/@lcap/basic-template@2.0.1/zip.tgz':
+    resolution: {integrity: sha512-pKe7Y0NHYNKlZoe/wPa/H/e0Q2B0g4hzE1lM7SC7vLgqaAs1b99Rlb+T+dtRAcl043ROyA8ozC2n8WqFgYfOZw==, tarball: file:lcap_modules/@lcap/basic-template@2.0.1/zip.tgz}
     version: 2.0.1
 
-  '@lcap/element-plus@http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/element-plus%401.0.0/zip.tgz':
-    resolution: {tarball: http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/element-plus%401.0.0/zip.tgz}
+  '@lcap/element-plus@file:lcap_modules/@lcap/element-plus@1.0.0/zip.tgz':
+    resolution: {integrity: sha512-WlHjC9j6xcyMzS5x5fxWkGUapTbS5kSO4D5reQMsxgb1cVDbFlS+a7U8Y8W1Hy+kQ+W/V1ku5NHd8NbcL2K16g==, tarball: file:lcap_modules/@lcap/element-plus@1.0.0/zip.tgz}
     version: 1.0.0
     peerDependencies:
       vue: ^3.5.0
@@ -792,9 +792,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  caniuse-lite@1.0.30001706:
-    resolution: {integrity: sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==}
 
   caniuse-lite@1.0.30001726:
     resolution: {integrity: sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==}
@@ -1595,9 +1592,6 @@ packages:
 
   normalize-wheel-es@1.2.0:
     resolution: {integrity: sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==}
-
-  normalize.css@7.0.0:
-    resolution: {integrity: sha512-LYaFZxj2Q1Q9e1VJ0f6laG46Rt5s9URhKyckNaA2vZnL/0gwQHWhM7ALQkp3WBQKM5sXRLQ5Ehrfkp+E/ZiCRg==}
 
   npm-normalize-package-bin@4.0.0:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
@@ -2428,7 +2422,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@lcap/basic-template@http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/basic-template%402.0.1/zip.tgz':
+  '@lcap/basic-template@file:lcap_modules/@lcap/basic-template@2.0.1/zip.tgz':
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1
       axios: 0.21.4
@@ -2446,7 +2440,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@lcap/element-plus@http://minio-api.codewave-test.163yun.com/lowcode-static/packages/%40lcap/element-plus%401.0.0/zip.tgz(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))':
+  '@lcap/element-plus@file:lcap_modules/@lcap/element-plus@1.0.0/zip.tgz(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@element-plus/icons-vue': 2.3.1(vue@3.5.13(typescript@5.7.3))
       '@lcap/validator': 1.0.0
@@ -2455,7 +2449,6 @@ snapshots:
       element-plus: 2.9.11(vue@3.5.13(typescript@5.7.3))
       immutable: 5.0.0-beta.4
       lodash: 4.17.21
-      normalize.css: 7.0.0
       vue: 3.5.13(typescript@5.7.3)
       vue-hooks-plus: 2.4.0(vue@3.5.13(typescript@5.7.3))
       vue-router: 4.5.0(vue@3.5.13(typescript@5.7.3))
@@ -3140,7 +3133,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001706
+      caniuse-lite: 1.0.30001726
       electron-to-chromium: 1.5.120
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
@@ -3164,8 +3157,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  caniuse-lite@1.0.30001706: {}
 
   caniuse-lite@1.0.30001726: {}
 
@@ -3906,8 +3897,6 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-wheel-es@1.2.0: {}
-
-  normalize.css@7.0.0: {}
 
   npm-normalize-package-bin@4.0.0: {}
 


### PR DESCRIPTION
cherry-pick into release/v2.0.1