### PR TITLE
fix: 提前创建i18n

### DIFF
--- a/packages/vue2/src/init.js
+++ b/packages/vue2/src/init.js
@@ -44,6 +44,11 @@ const init = (appConfig, platformConfig, routes, metaData) => {
   window.appInfo = Object.assign(appConfig, platformConfig);
 
   /**
+   * 🔒创建i18n
+   */
+  const i18n = setI18nLocale(appConfig);
+
+  /**
    * Vue全局错误捕获
    */
   Vue.config.errorHandler = (err, vm, info) => {
@@ -246,7 +251,7 @@ const init = (appConfig, platformConfig, routes, metaData) => {
   const app = new Vue({
     name: 'app',
     router,
-    i18n: setI18nLocale(appConfig),
+    i18n,
     pinia: createPinia(),
     ...App,
   });


### PR DESCRIPTION
由于制品bundle中全局变量文本中会调用$i18n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 统一 i18n 初始化为单实例，在应用启动时预创建并复用，减少重复初始化，提高稳定性与一致性。
  * 间接优化启动体验，避免多次构建语言资源，降低潜在的语言切换异常风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->