### PR TITLE
feat: 支持设置路由模式

### DIFF
--- a/packages/vue2/src/router/init.mobile.js
+++ b/packages/vue2/src/router/init.mobile.js
@@ -5,7 +5,7 @@ export function createRouter(routes) {
   Vue.use(VueRouter);
 
   const router = new VueRouter({
-    mode: 'history',
+    mode: window.LcapVueRouterConfig?.mode || 'history',
     base: window.LcapMicro?.routePrefix,
     routes,
   });
@@ -34,6 +34,10 @@ export function createRouter(routes) {
       }
     }
   });
+
+  if (window.LcapVueRouterConfig?.initRoute) {
+    router.replace(window.LcapVueRouterConfig.initRoute);
+  }
 
   return router;
 }

--- a/packages/vue2/src/router/init.pc.js
+++ b/packages/vue2/src/router/init.pc.js
@@ -8,7 +8,7 @@ export function createRouter(routes) {
   Vue.use(VueRouter);
 
   const router = new VueRouter({
-    mode: 'history',
+    mode: window.LcapVueRouterConfig?.mode || 'history',
     base: window.LcapMicro?.routePrefix,
     routes,
   });
@@ -17,6 +17,10 @@ export function createRouter(routes) {
    * 作用：提供全局访问路由实例的能力
    */
   window.VueRouterInstance = router;
+
+  if (window.LcapVueRouterConfig?.initRoute) {
+    router.replace(window.LcapVueRouterConfig.initRoute);
+  }
 
   return router;
 }

--- a/packages/vue3/source/src/common/router/init.js
+++ b/packages/vue3/source/src/common/router/init.js
@@ -3,7 +3,7 @@ import { createRouter, createWebHistory, createMemoryHistory, createWebHashHisto
 export function createRouterInstance(routes) {
   const fnMap = {
     history: createWebHistory,
-    memory: createMemoryHistory,
+    abstract: createMemoryHistory,
     hash: createWebHashHistory,
   }
   const createHistory = fnMap[window.LcapVueRouterConfig?.mode || 'history']

--- a/packages/vue3/source/src/common/router/init.js
+++ b/packages/vue3/source/src/common/router/init.js
@@ -1,10 +1,20 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHistory, createMemoryHistory, createWebHashHistory} from 'vue-router';
 
 export function createRouterInstance(routes) {
+  const fnMap = {
+    history: createWebHistory,
+    memory: createMemoryHistory,
+    hash: createWebHashHistory,
+  }
+  const createHistory = fnMap[window.LcapVueRouterConfig?.mode || 'history']
   const router = createRouter({
-    history: createWebHistory(window.LcapMicro?.routePrefix),
+    history: createHistory(window.LcapMicro?.routePrefix),
     routes,
   });
+
+  if (window.LcapVueRouterConfig?.initRoute) {
+    router.replace(window.LcapVueRouterConfig.initRoute);
+  }
 
   return router;
 }

--- a/packages/vue3/source/src/common/router/init.js
+++ b/packages/vue3/source/src/common/router/init.js
@@ -3,10 +3,15 @@ import { createRouter, createWebHistory, createMemoryHistory, createWebHashHisto
 export function createRouterInstance(routes) {
   const fnMap = {
     history: createWebHistory,
-    abstract: createMemoryHistory,
+    memory: createMemoryHistory,
     hash: createWebHashHistory,
   }
-  const createHistory = fnMap[window.LcapVueRouterConfig?.mode || 'history']
+  const mode = window.LcapVueRouterConfig?.mode || 'history';
+  const createHistory = fnMap[mode] || fnMap.history;
+  if (!fnMap[mode]) {
+    console.warn(`Unknown router mode: ${mode}, falling back to history mode`);
+  }
+
   const router = createRouter({
     history: createHistory(window.LcapMicro?.routePrefix),
     routes,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 路由模式可通过全局配置切换，默认使用 history，支持更多运行场景。
  - 启动时可按全局配置自动替换跳转到指定初始路由（使用替换而非新增历史记录）。
  - 在 Vue3 环境下额外支持 hash 与 memory 等路由历史模式，以适配不同部署与测试需求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->