### PR TITLE
fix: 初始化时将生命周期钩子设置为 undefined，以避免乾坤框架间接从主应用获取

### DIFF
--- a/packages/vue2/source/mobile/qiankun/main.js
+++ b/packages/vue2/source/mobile/qiankun/main.js
@@ -5,6 +5,13 @@ import platformConfig from "./platform.config.json";
 import { routes } from "./router/routes";
 import "./library";
 
+window.createLcapApp = undefined;
+window.rendered = undefined;
+window.preRequest = undefined;
+window.postRequest = undefined;
+window.beforeRoute = undefined;
+window.afterRoute = undefined;
+
 if (!window.__POWERED_BY_QIANKUN__) {
   cloudAdminDesigner.init(platformConfig?.appConfig, platformConfig, routes, metaData);
 }

--- a/packages/vue2/source/pc/qiankun/main.js
+++ b/packages/vue2/source/pc/qiankun/main.js
@@ -5,6 +5,13 @@ import platformConfig from "./platform.config.json";
 import { routes } from "./router/routes";
 import "./library";
 
+window.createLcapApp = undefined;
+window.rendered = undefined;
+window.preRequest = undefined;
+window.postRequest = undefined;
+window.beforeRoute = undefined;
+window.afterRoute = undefined;
+
 if (!window.__POWERED_BY_QIANKUN__) {
   cloudAdminDesigner.init(platformConfig?.appConfig, platformConfig, routes, metaData);
 }


### PR DESCRIPTION
cherry-pick into release/v2.0.0