### PR TITLE
fix: 初始化时将生命周期钩子设置为 undefined，以避免乾坤框架间接从主应用获取

### DIFF
--- a/packages/vue2/source/qiankun/main.js
+++ b/packages/vue2/source/qiankun/main.js
@@ -10,6 +10,13 @@ import platformConfig from "./platform.config.json";
 import '@/style/index.css';
 import '@/style/theme.css';
 
+window.createLcapApp = undefined;
+window.rendered = undefined;
+window.preRequest = undefined;
+window.postRequest = undefined;
+window.beforeRoute = undefined;
+window.afterRoute = undefined;
+
 // 写入国际化配置
 platformConfig.appConfig.i18nInfo = i18nInfo;
 


### PR DESCRIPTION
cherry-pick into release/v2.2.0