### PR TITLE
fix: vue2 源码模板依赖中添加@vue/composition-api

### DIFF
--- a/packages/vue2/source/mobile/package.json
+++ b/packages/vue2/source/mobile/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vue/composition-api": "1.7.1",
     "@vusion/utils": "^0.4.9",
     "babel-polyfill": "^6.26.0",
     "core-js": "^3.6.5",

--- a/packages/vue2/source/pc/package.json
+++ b/packages/vue2/source/pc/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vue/composition-api": "1.7.1",
     "@vusion/utils": "^0.4.10",
     "babel-polyfill": "^6.26.0",
     "core-js": "^3.6.5",


### PR DESCRIPTION
cherry-pick into release/v1.7.2