### PR TITLE
fix(vue3): 创建路由实例时启用大小写敏感

### DIFF
--- a/packages/vue3/source/src/common/router/init.js
+++ b/packages/vue3/source/src/common/router/init.js
@@ -15,7 +15,7 @@ export function createRouterInstance(routes) {
   const router = createRouter({
     history: createHistory(window.LcapMicro?.routePrefix),
     routes,
-    strict: true,
+    sensitive: true,
   });
 
   if (window.LcapVueRouterConfig?.initRoute) {

--- a/packages/vue3/source/src/common/router/init.js
+++ b/packages/vue3/source/src/common/router/init.js
@@ -15,6 +15,7 @@ export function createRouterInstance(routes) {
   const router = createRouter({
     history: createHistory(window.LcapMicro?.routePrefix),
     routes,
+    strict: true,
   });
 
   if (window.LcapVueRouterConfig?.initRoute) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 启用了区分大小写的路由匹配，修正了因大小写差异导致的路由识别问题，提升导航准确性与一致性，减少用户在路径输入或链接跳转时遇到的意外路由错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->