### PR TITLE
fix: 修复.prettierrc.js中的embeddedLanguageFormatting配置

### DIFF
--- a/packages/vue2/source/mobile/.prettierrc.js
+++ b/packages/vue2/source/mobile/.prettierrc.js
@@ -5,6 +5,7 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  embeddedLanguageFormatting: 'off',
   overrides: [
     {
       files: '*.vue',

--- a/packages/vue2/source/pc/.prettierrc.js
+++ b/packages/vue2/source/pc/.prettierrc.js
@@ -5,6 +5,7 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  embeddedLanguageFormatting: 'off',
   overrides: [
     {
       files: '*.vue',


### PR DESCRIPTION
cherry-pick into release/v2.1.0