### PR TITLE
fix: 修复.prettierrc.js中的embeddedLanguageFormatting配置

### DIFF
--- a/packages/vue2/source/.prettierrc.js
+++ b/packages/vue2/source/.prettierrc.js
@@ -5,6 +5,7 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  embeddedLanguageFormatting: 'off',
   overrides: [
     {
       files: '*.vue',

--- a/packages/vue3/source/.prettierrc.js
+++ b/packages/vue3/source/.prettierrc.js
@@ -5,6 +5,7 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  embeddedLanguageFormatting: 'off',
   overrides: [
     {
       files: '*.vue',


### PR DESCRIPTION
cherry-pick into release/v2.2.0