### PR TITLE
fix: 修复emitClientResource函数中router.min.js的时间戳添加逻辑 (#285)

### DIFF
--- a/packages/vue3/source/rspack/plugins/lcap.js
+++ b/packages/vue3/source/rspack/plugins/lcap.js
@@ -140,7 +140,10 @@ function emitClientResource(compiler, options) {
         const clientCode = `(function() {
           function loadAssets() {
             // chunksMap
-            ${isDev} && window.LazyLoad.js(["${publicPath}router.min.js?t=" + Date.now()]);
+            ${isDev} && window.LazyLoad.js(["${publicPath}router.min.js"].map(item => {
+              var timestamp = Date.now();
+              return item + '?timestamp=' + timestamp;
+            }));
 
             window.LazyLoad.js(${JSON.stringify(allJS)});
             window.LazyLoad.css(${JSON.stringify(allCSS)});


### PR DESCRIPTION
cherry-pick into release/v2.2.0