### PR TITLE
fix: 将数据源缓存从ref改为Map

### DIFF
--- a/packages/vue3/source/src/hooks/datasource-utils.js
+++ b/packages/vue3/source/src/hooks/datasource-utils.js
@@ -1,7 +1,7 @@
 import _isEqual from 'lodash/isEqual';
 
 export function useDataSourceUtils() {
-  const cache = new WeakMap();
+  const cache = new Map();
 
   function __isShallowEqualArray(arr1, arr2) {
     if (arr1.length !== arr2.length) return false;

--- a/packages/vue3/source/src/hooks/datasource-utils.js
+++ b/packages/vue3/source/src/hooks/datasource-utils.js
@@ -1,8 +1,7 @@
-import { ref } from 'vue';
 import _isEqual from 'lodash/isEqual';
 
 export function useDataSourceUtils() {
-  const cache = ref(new Map());
+  const cache = new WeakMap();
 
   function __isShallowEqualArray(arr1, arr2) {
     if (arr1.length !== arr2.length) return false;
@@ -19,9 +18,9 @@ export function useDataSourceUtils() {
 
   function __getDataSourceCacheFn(methodName, currentArray = []) {
     if (!currentArray.length) {
-      return cache.value.get(methodName);
+      return cache.get(methodName);
     }
-    for (let [key, value] of cache.value.entries()) {
+    for (let [key, value] of cache.entries()) {
       if (__isShallowEqualArray(key, [methodName, ...currentArray])) {
         return value;
       }
@@ -30,10 +29,10 @@ export function useDataSourceUtils() {
 
   function __setDataSourceCacheFn(methodName, currentArray = [], fn) {
     if (!currentArray.length) {
-      cache.value.set(methodName, fn);
+      cache.set(methodName, fn);
       return;
     }
-    cache.value.set([methodName, ...currentArray], fn);
+    cache.set([methodName, ...currentArray], fn);
   }
 
   function __getOrCreateDataSource(methodName, currentArray = [], newFn) {
@@ -47,6 +46,6 @@ export function useDataSourceUtils() {
 
   return {
     __getOrCreateDataSource,
-    private_data_source_cache: cache.value,
+    private_data_source_cache: cache,
   };
 }


### PR DESCRIPTION
背景： 由于使用了ref导致cache get到的缓存都被reactive处理了，导致isEqual失效

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 优化了内部数据源缓存的存储与访问方式，降低内存开销并提升性能。
  * 简化了缓存的使用路径，减少访问开销，提升运行效率和稳定性。
  * 调整了对外暴露的缓存形态，现在直接以原生对象形式提供缓存，可能影响依赖该字段的集成方式。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->