### PR TITLE
fix: 修复 lazyLoadCode 中正则表达式的转义字符错误

### DIFF
--- a/packages/vue3/source/rspack/plugins/lcap/constant.js
+++ b/packages/vue3/source/rspack/plugins/lcap/constant.js
@@ -166,9 +166,9 @@ const lazyLoadCode = `var LazyLoad = (function (doc) {
     }
     function preload(url) {
       var asAttr = '';
-      if (/\.js$/.test(url)) {
+      if (/\\.js$/.test(url)) {
         asAttr = 'script';
-      } else if (/\.css$/.test(url)) {
+      } else if (/\\.css$/.test(url)) {
         asAttr = 'style';
       }
       var node = createNode('link', {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 修复了Vue3 Rspack插件在懒加载资源时的文件类型识别问题，改进了对JavaScript和CSS文件的识别机制，提高了资源加载的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->