### PR TITLE
fix: 导出 install 模块以便于使用 (#362)

### DIFF
--- a/packages/vue2/src/utils/index.js
+++ b/packages/vue2/src/utils/index.js
@@ -24,3 +24,5 @@ export default {
   dataSourceUtils,
   createErrorLayout,
 };
+
+export * from './install';


### PR DESCRIPTION
cherry-pick into release/v2.2.0